### PR TITLE
Criação de diretório de Pacientes locais

### DIFF
--- a/Assets/_Game/Scripts/Core/Api/ApiClient.cs
+++ b/Assets/_Game/Scripts/Core/Api/ApiClient.cs
@@ -168,11 +168,11 @@ namespace Assets._Game.Scripts.Core.Api
             catch (HttpRequestException httpRequestException)
             {
                 Debug.LogWarning($"No internet connection!. Error: {httpRequestException}");
-                return new ApiResponse<List<PacientDto>>();
+                return new ApiResponse<List<PacientDto>>{Data = new List<PacientDto>()};
             }
 
             if(!response.IsSuccessStatusCode)
-                return new ApiResponse<List<PacientDto>>();
+                return new ApiResponse<List<PacientDto>> { Data = new List<PacientDto>() };
 
             var content = await response.Content.ReadAsStringAsync();
             var apiResponse = JsonConvert.DeserializeObject<ApiResponse<List<PacientDto>>>(content);

--- a/Assets/_Game/Scripts/Core/Data/Manager/LocalDataManager.cs
+++ b/Assets/_Game/Scripts/Core/Data/Manager/LocalDataManager.cs
@@ -94,6 +94,9 @@ namespace Ibit.Core.Data.Manager
         
         public List<PacientDto> GetPacientsLocal()
         {
+            if(!Directory.Exists($"{GameDataPaths.localDataPath}/Pacients"))
+                Directory.CreateDirectory($"{GameDataPaths.localDataPath}/Pacients");
+
             var pacientsDirectories = Directory.GetDirectories($"{GameDataPaths.localDataPath}/Pacients");
             var pacientsInfoPaths = pacientsDirectories.Select(x=>Directory.GetFiles(x).First()).ToArray();
             var pacients = pacientsInfoPaths.Select(DataManagerUtil.LoadJsonFile<PacientDto>).ToList();


### PR DESCRIPTION
**O que foi feito**

- Criado a pasta de pacientes locais caso não exista. Antes, caso fosse feita uma busca de pacientes locais e a pasta não existisse (jogo recém instalado), era lançada uma exceção de IO.
- Retornada uma lista vazia de pacientes caso o retorno da API não possua nenhum dado de pacientes.